### PR TITLE
Explicitado 0pt en thesis.sty

### DIFF
--- a/thesis.sty
+++ b/thesis.sty
@@ -54,7 +54,7 @@
 % Formato de capítulos y subcapítulos
 \usepackage{titlesec}                                          
 \titleformat{\chapter}{\normalfont\Large\bfseries}{\thechapter.}{1em}{}                         %
-\titlespacing*{\chapter}{pt}{0pt}{0pt} 
+\titlespacing*{\chapter}{0pt}{0pt}{0pt} 
 \titlespacing*{\section}{0pt}{0pt}{0pt}   
 %\renewcommand\thesection{\arabic{section}}
 \titlespacing*{\subsection}{0pt}{0pt}{0pt}     


### PR DESCRIPTION
Se cambia {pt} por {0pt} para especificar 0 puntos de sangría, error que impide la compilación.